### PR TITLE
Remove Python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ chmod +x build_osx_py3.5.sh
 
 ### Windows
 
-Please note, experimental PySide2 wheels for Python 2.7 are being built using MSVC2015. This could possibly result in hard-to-track issues as MSVC versions are being mixed (MSVC2008 for Python, MSVC2015 for Qt and MSVC2015 for PySide2). Wheels built for Python 3.5 does not have mixed MSVC versions and should be fine.
-
 Download and install:
 
 * [Microsoft C++ Visual Studio 2015, v14.0 (MSVC2015)](https://www.visualstudio.com/)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,26 +9,6 @@ environment:
   
   matrix:
 
-    # Qt 5.6, Python 2.7 32-bit, MSVC2015 (v14)
-    - PYTHON: "C:\\Python27"
-      QT: "C:\\Qt\\5.6\\msvc2015"
-      OPENSSL: "C:\\OpenSSL-Win32\\bin"
-      VS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat"
-      ARCH: x86
-      os: Visual Studio 2015
-      platform: x86
-      fast_finish: true
-
-    # Qt 5.6, Python 2.7 64-bit, MSVC2015 (v14)
-    - PYTHON: "C:\\Python27-x64"
-      QT: "C:\\Qt\\5.6\\msvc2015_64"
-      OPENSSL: "C:\\OpenSSL-Win64\\bin"
-      VS: "C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat"
-      ARCH: amd64
-      os: Visual Studio 2015
-      platform: x64
-      fast_finish: true
-
     # Qt 5.6, Python 3.5 32-bit, MSVC2015 (v14)
     - PYTHON: "C:\\Python35"
       QT: "C:\\Qt\\5.6\\msvc2015"


### PR DESCRIPTION
Removes wheel building for official Python 2.7 (which is built with MSVC2008) .... since MSVC2015 is used to build PySide2.
