### PR TITLE
Ubuntu 14.04 (#35)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,25 @@
 matrix:
   include:
+  # Ubuntu 14.04, Python 2.7
+  - os: linux
+    dist: trusty
+    sudo: required
+    language: python
+    python: 2.7
+    services:
+    - docker
+    env:
+    - DOCKER_OS=ubuntu14.04
+  # Ubuntu 14.04, Python 3.5
+  - os: linux
+    dist: trusty
+    sudo: required
+    language: python
+    python: 3.5
+    services:
+    - docker
+    env:
+    - DOCKER_OS=ubuntu14.04
   # Ubuntu 16.04, Python 2.7
   - os: linux
     dist: trusty

--- a/Dockerfile-ubuntu14.04-py2.7
+++ b/Dockerfile-ubuntu14.04-py2.7
@@ -1,0 +1,35 @@
+from ubuntu:14.04
+
+RUN apt-get update && \
+    apt-get install -qq -y \
+        software-properties-common \
+        python-pip python-dev \
+        build-essential git libxml2 libxslt1.1 libxml2-dev libxslt1-dev wget mesa-common-dev libglu1-mesa-dev && \
+    add-apt-repository -y ppa:beineri/opt-qt561-trusty && \
+    apt-get update && \
+    apt-get install -qq -y \
+        qt56-meta-full
+
+RUN wget --quiet https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.tar.gz
+RUN tar -xf cmake-3.5.2-Linux-x86_64.tar.gz -C /opt
+
+RUN git clone --recursive https://codereview.qt-project.org/pyside/pyside-setup /pyside-setup
+
+# /opt/qt56/bin/qt56-env.sh
+ENV QT_BASE_DIR /opt/qt56
+ENV QTDIR $QT_BASE_DIR
+ENV PATH $QT_BASE_DIR/bin:$PATH
+ENV LD_LIBRARY_PATH $QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH  # x86_64
+# ENV LD_LIBRARY_PATH $QT_BASE_DIR/lib/i386-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH  # i386
+ENV PKG_CONFIG_PATH $QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+
+
+
+ENTRYPOINT  \
+            # cat /opt/qt56/bin/qt56-env.sh > /pyside-setup/dist/qt56-env.sh && \
+            python \
+            pyside-setup/setup.py \
+            bdist_wheel \
+            --ignore-git \
+            --qmake=/opt/qt56/bin/qmake \
+            --cmake=/opt/cmake-3.5.2-Linux-x86_64/bin/cmake

--- a/Dockerfile-ubuntu14.04-py3.5
+++ b/Dockerfile-ubuntu14.04-py3.5
@@ -1,0 +1,35 @@
+from ubuntu:14.04
+
+RUN apt-get update && \
+    apt-get install -qq -y \
+        software-properties-common \
+        python3-pip python3-dev \
+        build-essential git libxml2 libxslt1.1 libxml2-dev libxslt1-dev wget mesa-common-dev libglu1-mesa-dev && \
+    add-apt-repository -y ppa:beineri/opt-qt561-trusty && \
+    apt-get update && \
+    apt-get install -qq -y \
+        qt56-meta-full
+
+RUN wget --quiet https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.tar.gz
+RUN tar -xf cmake-3.5.2-Linux-x86_64.tar.gz -C /opt
+
+RUN git clone --recursive https://codereview.qt-project.org/pyside/pyside-setup /pyside-setup
+
+# /opt/qt56/bin/qt56-env.sh
+ENV QT_BASE_DIR /opt/qt56
+ENV QTDIR $QT_BASE_DIR
+ENV PATH $QT_BASE_DIR/bin:$PATH
+ENV LD_LIBRARY_PATH $QT_BASE_DIR/lib/x86_64-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH  # x86_64
+# ENV LD_LIBRARY_PATH $QT_BASE_DIR/lib/i386-linux-gnu:$QT_BASE_DIR/lib:$LD_LIBRARY_PATH  # i386
+ENV PKG_CONFIG_PATH $QT_BASE_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
+
+
+
+ENTRYPOINT  \
+            # cat /opt/qt56/bin/qt56-env.sh > /pyside-setup/dist/qt56-env.sh && \
+            python3 \
+            pyside-setup/setup.py \
+            bdist_wheel \
+            --ignore-git \
+            --qmake=/opt/qt56/bin/qmake \
+            --cmake=/opt/cmake-3.5.2-Linux-x86_64/bin/cmake


### PR DESCRIPTION
- Skip libqt5quickwidgets5
- Use Cmake 3
- Add Ubuntu 14.04 to Travis CI
- Add Qt5 by Stephan Binner

https://launchpad.net/~beineri/+archive/ubuntu/opt-qt561-trusty
- Update repository
- Install software-properties-common
- Change order
- Test with qt56*
- Use envs from qt56-env.sh
- Use many RUN apt-get installs
- Add Ubuntu 14.04 with Python 3.5
- Use one "RUN apt-get install" command
- Fix duplicate
- Restore matrix
- Use alphabetic order in matrix
- Revert "Use alphabetic order in matrix"

This reverts commit 14a51e41743631a228537530b21ccfa783724d17.
